### PR TITLE
Corepack Support & Dependabot Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
   },
   "devDependencies": {
     "typescript": "^5.4.5"
-  }
+  },
+  "packageManager": "pnpm@9.4.0"
 }


### PR DESCRIPTION
This PR adds packageManager field to the package.json file of the project in order to support [Corepack](https://nodejs.org/api/corepack.html). This also fixes the issue with Dependabot version upgrades resetting the pnpm lockfile to v6.